### PR TITLE
Fix for cancelled login request

### DIFF
--- a/pyramid_openid/view.py
+++ b/pyramid_openid/view.py
@@ -69,6 +69,8 @@ def verify_openid(context, request):
         return process_incoming_request(context, request, incoming_openid_url)
     elif openid_mode == 'id_res':
         return process_provider_response(context, request)
+    elif openid_mode == 'cancel':
+        return error_to_login_form(request, 'Login request cancelled')
     return HTTPBadRequest()
 
 


### PR DESCRIPTION
Sends error message via error_to_login_form instead of returning
HTTPBadRequest in case of cancelled login request.

(I discovered pull requests, so I am sending my small fix this way... you can ignore previous issue from my)
